### PR TITLE
Fix lowercase normalization in norm_gloss

### DIFF
--- a/functions/modules/utils/text.py
+++ b/functions/modules/utils/text.py
@@ -3,7 +3,7 @@ from typing import List
 
 def norm_gloss(s: str) -> str:
     s = s.strip().lower()
-    s = re.sub(r"[^A-Z0-9]+", "_", s)
+    s = re.sub(r"[^a-z0-9]+", "_", s)
     s = re.sub(r"_+", "_", s).strip("_")
     return s
 


### PR DESCRIPTION
## Summary
- ensure `norm_gloss` retains lowercase letters by replacing the regex with one that matches lowercase alphabet and digits

## Testing
- `python -m pytest`
- `python - <<'PY'
import sys, os
sys.path.append('functions')
from modules.utils.text import norm_gloss
print(norm_gloss('Hello'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c6419a29b8832e98b6ff571a57f14d