### PR TITLE
Import norm_gloss in library handler

### DIFF
--- a/functions/modules/library.py
+++ b/functions/modules/library.py
@@ -1,8 +1,7 @@
-import json, logging
+import json
 from firebase_functions import https_fn
-from firebase_admin import storage
 from .utils.storage import blob_exists, ensure_inline, sign_v4_inline
-from .utils.text import candidates_for_filename
+from .utils.text import norm_gloss
 
 LIB_PREFIX = "slp_library"
 


### PR DESCRIPTION
## Summary
- fix NameError in library_link by importing `norm_gloss`
- tidy unused imports

## Testing
- `python -m py_compile functions/modules/library.py`
- `firebase deploy --only functions` (fails: Failed to authenticate)
- `curl -i https://us-east1-signtranslate-41971.cloudfunctions.net/library_link?gloss=double` (returns 403)


------
https://chatgpt.com/codex/tasks/task_e_68c679013810832ebd9cdbc380ffc17e