### PR TITLE
Broaden library lookup fields

### DIFF
--- a/functions/modules/library.py
+++ b/functions/modules/library.py
@@ -1,29 +1,60 @@
 import json
+from typing import Optional
+
+import firebase_admin.firestore
 from firebase_functions import https_fn
-from .utils.storage import blob_exists, ensure_inline, sign_v4_inline
+from .utils.storage import ensure_inline, sign_v4_inline
 from .utils.text import norm_gloss_lower
 
-LIB_PREFIX = "slp_library"
+
+def _first_non_empty(*values: object) -> Optional[str]:
+    for value in values:
+        if isinstance(value, str):
+            trimmed = value.strip()
+            if trimmed:
+                return trimmed
+    return None
+
 
 def handle_library_link(req: https_fn.Request) -> https_fn.Response:
-    gloss = req.args.get("gloss") if req.method == "GET" else None
+    gloss = req.args.get("gloss")
+    normalized = req.args.get("g")
+
     if req.method != "GET":
         try:
             payload = json.loads(req.get_data().decode("utf-8"))
             gloss = gloss or payload.get("gloss")
+            normalized = normalized or payload.get("g")
         except Exception:
             return https_fn.Response("Invalid JSON", status=400)
-    if not gloss:
-        return https_fn.Response("Missing 'gloss'", status=400)
 
-    g = norm_gloss_lower(gloss)
-    key = f"{LIB_PREFIX}/{g}.mp4"
+    gloss_source = _first_non_empty(normalized, gloss)
+    if not gloss_source:
+        return https_fn.Response("Missing 'gloss' or 'g'", status=400)
+
+    g = norm_gloss_lower(gloss_source)
+
     try:
-        if not blob_exists(key):
-            return https_fn.Response(f"gloss not found: {g}", status=404)
+        db = firebase_admin.firestore.client()
+        collection = db.collection("library_table")
+        doc = None
+        for field in ("normalized_gloss", "gloss_en"):
+            query = collection.where(field, "==", g).limit(1)
+            docs_iter = query.stream()
+            doc = next(docs_iter, None)
+            if doc:
+                break
     except Exception as e:
-        print(f"Error checking blob existence for {key}: {e}")
-        return https_fn.Response("Internal server error: failed to check blob existence", status=500)
+        print(f"Error querying Firestore for gloss {g}: {e}")
+        return https_fn.Response("Internal server error: failed to query library table", status=500)
+
+    if not doc:
+        return https_fn.Response(f"gloss not found: {g}", status=404)
+
+    data = doc.to_dict() if doc else None
+    key = (data or {}).get("storage_location")
+    if not key:
+        return https_fn.Response(f"storage location missing for gloss: {g}", status=404)
 
     try:
         ensure_inline(key)


### PR DESCRIPTION
## Summary
- try fetching library_table documents by either normalized_gloss or gloss_en
- keep returning the stored storage_location metadata when a record is located
- accept the normalized gloss parameter `g` as an alternative request input

## Testing
- python -m compileall functions/modules/library.py

------
https://chatgpt.com/codex/tasks/task_e_68c8c9f54108832eba35e15245f5ab31